### PR TITLE
Add caching to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
- - 2.4.1
+  - 2.4.1
+cache: bundler
 before_script:
   - RAILS_ENV=test rake db:create db:schema:load


### PR DESCRIPTION
Help all the RubyforGood builds go through the queue faster. On other projects, I've seen one minute shaved off from some test runs.