### PR TITLE
Remove initializer wrapping

### DIFF
--- a/app/controllers/api/appointments_controller.rb
+++ b/app/controllers/api/appointments_controller.rb
@@ -5,16 +5,18 @@ class API::AppointmentsController < ApplicationController
     appointments = Appointment.includes(:client)
 
     render json: {
-      appointments: appointments.map(&:attributes),
-      clients: appointments.map(&:client).map(&:attributes),
+      appointments: appointments.as_json,
+      clients: appointments.map(&:client).as_json,
     }
   end
 
   def show
     appt = Appointment.includes(:client).find_by(id: params[:id])
     if appt
-      client_json = appt.client.as_json
-      render json: appt.as_json.merge(client_json)
+      render json: {
+        appointment: appt.as_json,
+        client: appt.client.as_json,
+      }
     else
       render json: {
         errors: {
@@ -28,9 +30,9 @@ class API::AppointmentsController < ApplicationController
     appointments = Appointment.for_day(Date.today)
 
     render json: {
-      appointments: appointments.map(&:attributes),
-      clients: appointments.map(&:client).map(&:attributes),
-      notes: appointments.flat_map(&:notes).map(&:attributes),
+      appointments: appointments.as_json,
+      clients: appointments.map(&:client).as_json,
+      notes: appointments.flat_map(&:notes).as_json,
     }
   end
 

--- a/app/controllers/api/clients_controller.rb
+++ b/app/controllers/api/clients_controller.rb
@@ -1,9 +1,16 @@
 class API::ClientsController < ApplicationController
   respond_to :json
+
+  def index
+    clients = Client.all
+
+    render json: { clients: clients.as_json }
+  end
+
   def create
     client = Client.create!(create_params)
 
-    render json: client.as_json
+    render json: { client: client.as_json }
   end
 
   private

--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -11,12 +11,12 @@ class API::NotesController < ApplicationController
 
     note.update(note_params)
 
-    render json: note.as_json
+    render json: { note: note.as_json }
   end
 
   def create
     note = find_memoable.notes.create(note_params)
-    render json: note.as_json
+    render json: { note: note.as_json }
   end
 
   private

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -7,8 +7,3 @@
 ActiveSupport.on_load(:action_controller) do
   wrap_parameters format: [:json]
 end
-
-# To enable root element in JSON for ActiveRecord objects.
-ActiveSupport.on_load(:active_record) do
-  self.include_root_in_json = true
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   resources :users, only: [:create]
 
   namespace :api do
+    resources :clients
     resources :appointments do
       collection do
         get :today
@@ -18,9 +19,4 @@ Rails.application.routes.draw do
 
   root to: 'home#index'
   get '*all' => 'home#index'
-
-  namespace :api do
-    resources :clients
-    resources :appointments
-  end
 end


### PR DESCRIPTION
For arrays of objects, we don't want every individual object to be wrapped in an additional key/value pair.

Removing the initializer the structure becomes more apparent by looking at the controllers' code.  