### PR TITLE
Add 'C' & 'H' designators to client form

### DIFF
--- a/app/javascript/client-form.js
+++ b/app/javascript/client-form.js
@@ -112,8 +112,8 @@ export default class ClientForm extends Component {
           </select>
         </div>
         <div style={styles.row}>
-          <legend style={styles.bold}>Phone</legend>
-          <label>(H): </label>
+          <label style={styles.bold}>Phone </label>
+          <label>(H):</label>
           <input
             ref={(element) => this.phoneNumber = element}
             defaultValue={this.props.client.phone_number}
@@ -121,7 +121,7 @@ export default class ClientForm extends Component {
             placeholder="Home number"
           />
           {'  '}
-          <label>(C): </label>
+          <label>(C):</label>
           <input
             ref={(element) => this.cellNumber = element}
             defaultValue={this.props.client.cell_number}

--- a/app/javascript/client-form.js
+++ b/app/javascript/client-form.js
@@ -112,18 +112,21 @@ export default class ClientForm extends Component {
           </select>
         </div>
         <div style={styles.row}>
-          <label>Phone: </label>
+          <legend style={styles.bold}>Phone</legend>
+          <label>(H): </label>
           <input
             ref={(element) => this.phoneNumber = element}
             defaultValue={this.props.client.phone_number}
             disabled={this.state.saving}
-            placeholder="Home"
+            placeholder="Home number"
           />
+          {'  '}
+          <label>(C): </label>
           <input
             ref={(element) => this.cellNumber = element}
             defaultValue={this.props.client.cell_number}
             disabled={this.state.saving}
-            placeholder="Cell"
+            placeholder="Cell number"
           />
         </div>
         <div>


### PR DESCRIPTION
Here's how I've got it looking now-- tried to implement something that would look natural when the form is first being filled out as well as when it's being viewed with information. Happy to make adjustments, though:
<img width="691" alt="screen shot 2017-07-08 at 12 58 36 pm" src="https://user-images.githubusercontent.com/11711662/27987562-40eeac04-63dd-11e7-9025-bf0d96eff423.png">
<img width="685" alt="screen shot 2017-07-08 at 12 58 09 pm" src="https://user-images.githubusercontent.com/11711662/27987563-43913c4c-63dd-11e7-8772-0b896da5b31f.png">
