### PR TITLE
enhance client endpoints, tweaks for data consistency

### DIFF
--- a/app/controllers/api/appointments_controller.rb
+++ b/app/controllers/api/appointments_controller.rb
@@ -55,22 +55,6 @@ class API::AppointmentsController < APIController
 
   private
 
-  def render_errors(appt)
-    render json: {
-      errors: {
-        message: appt.errors.full_messages.first
-      }
-    }, status: 400
-  end
-
-  def render_not_found
-    render json: {
-      errors: {
-        message: 'Not found'
-      }
-    }, status: 404
-  end
-
   def appointment_params
     params.require(:appointment).permit(:time, :client_id, :num_adults, :num_children, :usda_qualifier, :checked_in_at, appointment_type: [])
   end

--- a/app/controllers/api/clients_controller.rb
+++ b/app/controllers/api/clients_controller.rb
@@ -8,15 +8,23 @@ class API::ClientsController < APIController
   end
 
   def create
-    client = Client.create!(create_params)
+    client = Client.new(client_params)
 
-    render json: { client: client.as_json }
+    if client.save
+      render json: { client: client.as_json }
+    else
+      render_errors(client)
+    end
   end
 
   def update
     client = Client.find(params[:id])
-    client.update(create_params)
-    render json: { client: client.as_json }
+
+    if client.update(client_params)
+      render json: { client: client.as_json }
+    else
+      render_errors(client)
+    end
   end
 
   def autocomplete_name
@@ -29,7 +37,7 @@ class API::ClientsController < APIController
 
   private
 
-  def create_params
+  def client_params
     params
       .require(:client)
       .permit(

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -4,4 +4,20 @@ class APIController < ActionController::Base
   def handle_unverified_request
     # Do nothing. API requests don't need CSRF verification.
   end
+
+  def render_errors(object)
+    render json: {
+      errors: {
+        message: object.errors.full_messages.first
+      }
+    }, status: 400
+  end
+
+  def render_not_found
+    render json: {
+      errors: {
+        message: 'Not found'
+      }
+    }, status: 404
+  end
 end

--- a/app/javascript/client-form.js
+++ b/app/javascript/client-form.js
@@ -109,9 +109,9 @@ export default class ClientForm extends Component {
             disabled={this.state.saving}
           >
             <option />
-            <option>Anne Arundel</option>
-            <option>Howard</option>
-            <option>Prince George</option>
+            <option value="AA">Anne Arundel</option>
+            <option value="HO">Howard</option>
+            <option value="PG">Prince George</option>
           </select>
         </div>
         <div style={styles.row}>

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -2,6 +2,15 @@ class Client < ApplicationRecord
   has_many :appointments
   has_many :notes, as: :memoable
 
+  validates :first_name, presence: true
+  validates :last_name, presence: true
+  validates :address, presence: true
+  validates_inclusion_of :county, in: ['PG', 'AA', 'HO']
+  validates :zip, presence: true
+  validates :num_adults, presence: true
+  validates :num_children, presence: true
+  validates_inclusion_of :usda_qualifier, in: [true, false]
+
   def num_adults=(value, appointment_sync_occurred: false)
     super(value)
     sync_future_appointments('num_adults', value) unless appointment_sync_occurred

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -4,8 +4,11 @@ Faker::Config.locale = 'en-US'
 require 'discrete_distribution'
 
 # Login user
-unless User.find_by(email: 'admin@example.com')
-  login_user = User.create!(
+existing_user = User.find_by(email: 'admin@example.com')
+login_user = if existing_user
+  existing_user
+else
+  User.create!(
     email: 'admin@example.com',
     password: 'abc123',
     password_confirmation: 'abc123',
@@ -39,7 +42,7 @@ possible_counties = DiscreteDistribution.new(
 
 clients = Array.new(100) do
   county = possible_counties.sample
-  usda_cert_date = ((Faker::Date.between(11.months.ago, Date.today + 1.month) if county == 'PG') if rand < 0.9)
+  usda_cert_date = ((Faker::Date.between(Date.today - 11.months, Date.today + 1.month) if county == 'PG') if rand < 0.9)
   putc '.'
 
   Client.create!(
@@ -60,7 +63,7 @@ end
 
 appointments = Array.new(500) do
   client = clients.sample
-  date = Faker::Date.between(1.year.ago, Date.today + 2.months)
+  date = Faker::Date.between(Date.today - 1.year, Date.today + 2.months)
   time = Faker::Time.between(date, date, :morning) if date <= Date.today && rand < 0.9
   putc '.'
 

--- a/spec/factories/appointments.rb
+++ b/spec/factories/appointments.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :appointment do
     association :client
-    time Time.now
+    time Date.today
     num_children 12
     num_adults 15
     usda_qualifier false

--- a/spec/factories/clients.rb
+++ b/spec/factories/clients.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     first_name     "Sally"
     last_name      "Smith"
     address        "123 Main St"
-    county         'Baltimore'
+    county         'AA'
     zip            '21201'
     num_adults     12
     num_children   15

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Appointment, :type => :model do
   context "Appointment is created" do
     let (:initial_num_adults) { 2 }
     let (:initial_num_children) { 3 }
-    let (:client) { Client.create(first_name: "Paige", last_name: "Bolduc", address: "123 land", county: "Baltimore", zip: 21210, num_adults: initial_num_adults, num_children: initial_num_children, usda_qualifier: true) }
+    let (:client) { Client.create(first_name: "Paige", last_name: "Bolduc", address: "123 land", county: "AA", zip: 21210, num_adults: initial_num_adults, num_children: initial_num_children, usda_qualifier: true) }
     let(:default_attrs) {
       {
         time: Date.parse('31-12-2010'),

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe Client, :type => :model do
   context "Client family size is updated" do
     let(:initial_num_adults) { 2 }
     let(:initial_num_children) { 3 }
-    let(:client) { Client.create(first_name: "Paige", last_name: "Bolduc", address: "123 land", county: "Baltimore", zip: 21210, num_adults: initial_num_adults, num_children: initial_num_children, usda_qualifier: true) }
-    let!(:today_appt)   { FactoryGirl.create(:appointment, client: client, num_adults: initial_num_adults, num_children: initial_num_children, time: DateTime.now) }
-    let!(:future_appt)   { FactoryGirl.create(:appointment, client: client, num_adults: initial_num_adults, num_children: initial_num_children, time: DateTime.now + 1) }
-    let!(:past_appt)   { FactoryGirl.create(:appointment, client: client, num_adults: initial_num_adults, num_children: initial_num_children, time: DateTime.now - 1) }
+    let(:client) { Client.create(first_name: "Paige", last_name: "Bolduc", address: "123 land", county: "AA", zip: 21210, num_adults: initial_num_adults, num_children: initial_num_children, usda_qualifier: true) }
+    let!(:today_appt)   { FactoryGirl.create(:appointment, client: client, num_adults: initial_num_adults, num_children: initial_num_children, time: Date.today) }
+    let!(:future_appt)   { FactoryGirl.create(:appointment, client: client, num_adults: initial_num_adults, num_children: initial_num_children, time: Date.today + 1) }
+    let!(:past_appt)   { FactoryGirl.create(:appointment, client: client, num_adults: initial_num_adults, num_children: initial_num_children, time: Date.today - 1) }
 
     before do
       client.reload.update(num_adults: initial_num_adults * 2, num_children: initial_num_children * 2)

--- a/spec/requests/appointment_management_spec.rb
+++ b/spec/requests/appointment_management_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Appointment Managment", type: :request do
   let!(:client) { FactoryGirl.create(:client) }
-  let!(:appt)   { FactoryGirl.create(:appointment, client: client, time: Time.now) }
+  let!(:appt)   { FactoryGirl.create(:appointment, client: client, time: Date.today) }
 
   let (:response_json) { JSON.parse(response.body, symbolize_names: true) }
 
@@ -25,9 +25,9 @@ RSpec.describe "Appointment Managment", type: :request do
   end
 
   describe 'today' do
-    let!(:yesterday) { FactoryGirl.create(:appointment, client: client, time: 1.day.ago) }
+    let!(:yesterday) { FactoryGirl.create(:appointment, client: client, time: Date.today - 1) }
     let!(:today)     { appt }
-    let!(:tomorrow)  { FactoryGirl.create(:appointment, client: client, time: 1.day.from_now) }
+    let!(:tomorrow)  { FactoryGirl.create(:appointment, client: client, time: Date.today + 1) }
 
     it 'fetches appointments for today' do
       get '/api/appointments/today.json'

--- a/spec/requests/client_management_spec.rb
+++ b/spec/requests/client_management_spec.rb
@@ -1,29 +1,73 @@
 require "rails_helper"
 
 RSpec.describe "Client Managment", type: :request do
+  let (:response_json) { JSON.parse(response.body, symbolize_names: true) }
+  let(:client_params) do
+    {
+      first_name: "Sally",
+      last_name: "Smith",
+      address: "123 Main St",
+      county: 'AA',
+      zip: '21201',
+      num_adults: 12,
+      num_children: 15,
+      usda_qualifier: false,
+    }
+  end
+
   describe "create" do
-    let(:client_params) do
-      {
-        first_name: "Sally",
-        last_name: "Smith",
-        address: "123 Main St",
-        county: 'Baltimore',
-        zip: '21201',
-        num_adults: 12,
-        num_children: 15,
-        usda_qualifier: false,
-      }
-    end
-    it "Creates a Client" do
+    it "creates a Client" do
       expect {
         post "/api/clients.json", params: { client: client_params }
       }.to change(Client, :count).by(1)
     end
 
-    it "Returns Json for the new client" do
+    it "returns Json for the new client" do
       post "/api/clients.json", params: { client: client_params }
 
-      expect(JSON.parse(response.body).fetch("client")).to include("first_name" => "Sally", "last_name" => "Smith")
+      expect(response_json.fetch(:client)).to include(first_name: "Sally", last_name: "Smith")
+    end
+
+    it 'returns a 400 when errors occur' do
+      incomplete_params = client_params.merge(first_name: nil)
+
+      expect(
+        post "/api/clients.json", params: { client: incomplete_params }
+      ).to equal(400)
+    end
+
+    it 'handles errors' do
+      incomplete_params = client_params.merge(first_name: nil)
+
+      post "/api/clients.json", params: { client: incomplete_params }
+
+      expect(response_json).to have_key(:errors)
+    end
+  end
+
+  describe 'update' do
+    let!(:client) { FactoryGirl.create(:client) }
+
+    it 'successfully updates client' do
+      put "/api/clients/#{client.id}.json", params: { client: {first_name: 'Update'} }
+
+      expect(client.reload.first_name).to eql('Update')
+    end
+
+    it 'returns a 400 when errors occur' do
+      incomplete_params = client_params.merge(first_name: nil)
+
+      expect(
+        put "/api/clients/#{client.id}.json", params: { client: incomplete_params }
+      ).to equal(400)
+    end
+
+    it 'handles errors' do
+      incomplete_params = client_params.merge(first_name: nil)
+
+      put "/api/clients/#{client.id}.json", params: { client: incomplete_params }
+
+      expect(response_json).to have_key(:errors)
     end
   end
 
@@ -37,12 +81,30 @@ RSpec.describe "Client Managment", type: :request do
     end
 
     it "retrieves all clients" do
-      expect(JSON.parse(response.body).fetch("clients").count).to equal(2)
+      expect(response_json.fetch(:clients).count).to equal(2)
     end
 
     it "returns nested notes" do
-      expect(JSON.parse(response.body).fetch("clients").first).to include("notes" => [])
-      expect(JSON.parse(response.body).fetch("clients").last).to include("notes" => [{"id"=>note.id, "body"=>"some text", "memoable_type"=>"Client", "memoable_id"=>client_with_notes.id, "author_id" => note.author_id}])
+      expect(response_json.fetch(:clients).first).to include(notes: [])
+      expect(response_json.fetch(:clients).last).to include(notes: [{id: note.id, body: "some text", memoable_type: "Client", memoable_id: client_with_notes.id, author_id: note.author_id}])
+    end
+  end
+
+  describe 'autocomplete_name' do
+    let (:query_name) {'Name'}
+
+    it 'returns clients with matching first names' do
+      client = FactoryGirl.create(:client, first_name: query_name)
+      get "/api/clients/autocomplete_name/#{query_name}.json"
+
+      expect(response_json).to include(clients: [client.as_json.symbolize_keys])
+    end
+
+    it 'returns clients with matching last names' do
+      client = FactoryGirl.create(:client, last_name: query_name)
+      get "/api/clients/autocomplete_name/#{query_name}.json"
+
+      expect(response_json).to include(clients: [client.as_json.symbolize_keys])
     end
   end
 end


### PR DESCRIPTION
This PR accomplishes several things:
 
**Issue #17 - tests and error handling for clients endpoints**

* moved render_errors and render_not_found up to the API Controller
* validations for the client class, to further enhance error handling

**Issue #80 - counties should be restricted**

* this is handled with a model level validation
* on the front end, the dropdown still hold the full name but submits the abbreviation

**Cleanup**

* previously we were not handling time zones very consistently, and some tests would occasionally fail because of it
* after peaking with @pollygee about business requirements, it was established that we can focus on associating appointments with dates and not times for MVP
