### PR TITLE
Change Appt Notes to Client Notes & show on client form 

### DIFF
--- a/app/controllers/api/appointments_controller.rb
+++ b/app/controllers/api/appointments_controller.rb
@@ -22,11 +22,12 @@ class API::AppointmentsController < APIController
 
   def today
     appointments = Appointment.for_day(Date.today)
+    client_notes = serialized_notes(appointments.map(&:client).flat_map(&:notes))
 
     render json: {
       appointments: appointments.as_json,
       clients: appointments.map(&:client).as_json,
-      notes: serialized_notes(appointments.flat_map(&:notes)),
+      notes: client_notes,
     }
   end
 

--- a/app/javascript/client-form.js
+++ b/app/javascript/client-form.js
@@ -203,7 +203,7 @@ export default class ClientForm extends Component {
   }
 
   renderNotesSection() {
-    if (this.props.notes.length > 0) {
+    if (this.props.notes && this.props.notes.length > 0) {
       return (
         this.props.notes.map(note => (
           <div key={note.id} style={styles.note}>

--- a/app/javascript/client-form.js
+++ b/app/javascript/client-form.js
@@ -187,6 +187,11 @@ export default class ClientForm extends Component {
           }
         </div>
 
+        <div style={styles.row}>
+          <label style={styles.bold}>Notes: </label>
+          {this.renderNotesSection()}
+        </div>
+
         <div>
           <button style={styles.button} onClick={this.submit.bind(this)}>Save</button>
           { this.props.onCheckIn && (
@@ -196,6 +201,18 @@ export default class ClientForm extends Component {
       </form>
     );
   }
+
+  renderNotesSection() {
+    if (this.props.notes.length > 0) {
+      return (
+        this.props.notes.map(note => (
+          <div key={note.id} style={styles.note}>
+            <p>{note.body}</p>
+          </div>
+        )));
+     }
+     return <div>N/A</div>;
+   }
 }
 
 ClientForm.propTypes = {
@@ -213,5 +230,9 @@ const styles = {
   button: {
     marginTop: 10,
     padding: 10,
+  },
+  note: {
+    margin: '0.25em 0',
+    padding: '0 0.5em',
   },
 };

--- a/app/javascript/dashboard.js
+++ b/app/javascript/dashboard.js
@@ -72,7 +72,7 @@ export default class Dashboard extends React.Component {
                   c.id === appt.client_id
                 ));
                 const notes = this.state.notes.filter(note => (
-                  note.memoable_type === 'Appointment' && note.memoable_id === appt.id
+                  note.memoable_type === 'Client' && note.memoable_id === appt.client_id
                 ))
 
                 return (
@@ -82,7 +82,7 @@ export default class Dashboard extends React.Component {
                     <td style={Style.appointmentTableCellCentered}>{client.num_adults + client.num_children}</td>
                     <td style={Style.appointmentTableCellCentered}>
                       <button
-                        onClick={() => this.showNotes(appt.id)}
+                        onClick={() => this.showNotes(appt.client_id)}
                         style={{ display: 'inline-block', width: '100%' }}
                       >
                         {notes.length > 0 ? notes.length : ''} Note{notes.length === 1 ? '' : 's'}
@@ -130,9 +130,9 @@ export default class Dashboard extends React.Component {
     return filtered;
   }
 
-  showNotes(apptId) {
+  showNotes(clientId) {
     this.setState({
-      apptNotes: apptId,
+      clientNotesId: clientId,
     });
   }
 
@@ -154,13 +154,13 @@ export default class Dashboard extends React.Component {
   }
 
   modal() {
-    if(this.state.apptNotes) {
+    if(this.state.clientNotesId) {
       return (
         <Modal onClose={() => this.showNotes(null)}>
           <div>
             {
               this.state.notes.filter((note) => (
-                note.memoable_type === 'Appointment' && note.memoable_id === this.state.apptNotes
+                note.memoable_type === 'Client' && note.memoable_id === this.state.clientNotesId
               )).map(note => (
                 <div key={note.id} style={Style.note}>
                   <p>{note.body}</p>
@@ -168,7 +168,7 @@ export default class Dashboard extends React.Component {
                   <button
                     style={Style.deleteNoteButton}
                     onClick={() => {
-                      fetch(`/api/appointments/${this.state.apptNotes}/notes/${note.id}`, {
+                      fetch(`/api/clients/${this.state.clientNotesId}/notes/${note.id}`, {
                         method: 'DELETE',
                         credentials: 'include',
                       }).then(() => {
@@ -189,7 +189,7 @@ export default class Dashboard extends React.Component {
             }
             <NewNote
               key="new-note"
-              appointmentId={this.state.apptNotes}
+              clientId={this.state.clientNotesId}
               onSave={({ note }) => {
                 this.setState({
                   notes: this.state.notes.concat(note),
@@ -254,7 +254,7 @@ class NewNote extends React.Component {
   save(event) {
     event.preventDefault();
 
-    return fetch(`/api/appointments/${this.props.appointmentId}/notes`, {
+    return fetch(`/api/clients/${this.props.clientId}/notes`, {
       method: 'POST',
       credentials: 'include',
       headers: {

--- a/app/javascript/dashboard.js
+++ b/app/javascript/dashboard.js
@@ -202,12 +202,21 @@ export default class Dashboard extends React.Component {
     }
   }
 
+  getClientNotes() {
+    if (this.state.currentCheckIn) {
+      return this.state.notes.filter((note) => (
+        note.memoable_type === 'Client' && note.memoable_id === this.state.currentCheckIn.appointment.client_id
+      ))
+    }
+  }
+
   checkinModal() {
     if (this.state.currentCheckIn) {
       return (
         <Modal onClose={() => this.setState({currentCheckIn: null})}>
           <ClientForm
             client={this.state.currentCheckIn.client}
+            notes={this.getClientNotes()}
             appointment={this.state.currentCheckIn.appointment}
             onSave={this.updateClient.bind(this)}
             onCheckIn={this.checkIn.bind(this)}

--- a/app/javascript/directory.js
+++ b/app/javascript/directory.js
@@ -53,6 +53,7 @@ export default class Directory extends React.Component {
         <Modal onClose={() => this.setState({currentClient: null})}>
           <ClientForm
             client={this.state.currentClient}
+            notes={this.state.currentClient.notes}
             onSave={(client) => {
               this.updateClient(client)
               this.setState({ currentClient: null })


### PR DESCRIPTION
This PR changes the "Notes" button on the dashboard to reference the notes for the client instead of the specific appointment (and updates, additions, & deletions get saved as client notes, not appt. notes).

Also adds the display of notes to the Client Form (i.e. used in the check-in modal and client directory modal), if notes exist.