### PR TITLE
Default new appointment type to food

### DIFF
--- a/app/javascript/new-appointment.js
+++ b/app/javascript/new-appointment.js
@@ -10,7 +10,7 @@ export default class NewAppointment extends React.Component {
     this.state = {
       client: {},
       autocompleteClients: [],
-      appointmentType: [],
+      appointmentType: ["food"],
       appointmentDate: moment(),
     };
   }
@@ -113,6 +113,7 @@ export default class NewAppointment extends React.Component {
               <label>
                 <input
                   type="checkbox"
+                  defaultChecked={includes(this.state.appointmentType, 'food')}
                   onChange={(event) => {
                     this.setState({
                       appointmentType: includes(this.state.appointmentType, 'food') ?


### PR DESCRIPTION
This makes the default type for a new appointment be food.

@pollygee -- In working on this, I realized that I don't think the current check-in form displays the appointment type anywhere. Maybe take a look and see if you can find it? That might be something we need to add an issue about adding.