### PR TITLE
Webpack-error-update-README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,14 @@ Running the front-end React application:
     $ yarn install
     $ ./bin/webpack-dev-server
     navigate to localhost:3000 in the browser
+
+*** Webpack error ****
+
+Resolving webpack error after running rails s and navigating to localhost:3000:
+
+    $ Run ./bin/rails webpacker:install and ./bin/yarn install
+    $ Run bin/webpack-dev-server
+
+    Close your terminal
+
+    $ Run rails s again


### PR DESCRIPTION
When I set up my dev environment and ran rails s, I encountered a webpack error.

![screen shot 2017-09-13 at 1 46 03 pm](https://user-images.githubusercontent.com/4694248/30392152-f08f4444-9889-11e7-8bd4-73e5e66354e6.png)

I thought I'd add the commands I used to get around it to the README in case a future contributor has the same problem. 
