### PR TITLE
Fixes issue with modal not being scrollable

### DIFF
--- a/app/javascript/modal.js
+++ b/app/javascript/modal.js
@@ -23,6 +23,7 @@ const Style = {
   },
   modalOverlay: {
     position: 'fixed',
+    overflow: 'scroll',
     top: 0,
     bottom: 0,
     left: 0,


### PR DESCRIPTION
If a lot of client notes are added, the modal
goes off the bottom of the page, but isn't
scrollable, so there's no way to save edits or
see the bottom. This change makes the modal scrollable.